### PR TITLE
Added services to check if queue recevied data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,12 @@ add_service_files(FILES
     PlugSot.srv
     GetInt.srv
     ReadQueue.srv
-    WaitForMinQueueSize.srv
     GetBasePoseAtParam.srv
     # Still useful ?
     SetInt.srv
     SetPose.srv
+    WaitForQueueRecData.srv
+    SetQueueRecData.srv
   )
 
 add_message_files(FILES

--- a/srv/SetQueueRecData.srv
+++ b/srv/SetQueueRecData.srv
@@ -1,0 +1,2 @@
+bool status
+---

--- a/srv/WaitForQueueRecData.srv
+++ b/srv/WaitForQueueRecData.srv
@@ -1,4 +1,3 @@
-int32 minQueueSize
 # timeout in seconds
 float64 timeout
 ---


### PR DESCRIPTION
This pull-request is in continuation to the pull request https://github.com/stack-of-tasks/dynamic_graph_bridge/pull/108. 
 
## Updates in agimus_sot_msgs

**CMakeLists.txt and Services**
Addition of new services 
- WaitForQueueRecData.srv - Service to check if the RosSubscribeQueue has received at-least one data-point 
- SetQueueRecData.srv to check - Service to manually set the queue data reception status

Deletion of the service WaitForMinQueueSize.srv. This service is replaced WaitForQueueRecData.srv